### PR TITLE
Generate Router map tree using App directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
-export * from "./functions"
-export * from "./types"
+import { generateRouteMap } from "./routeMapGenerator";
+
+export * from "./functions";
+export * from "./types";
+export * from "./routeMapGenerator";
+
 
 //? Sample Route map
 //   export const routeMap: RouteMap = {

--- a/src/routeMapGenerator.ts
+++ b/src/routeMapGenerator.ts
@@ -1,0 +1,37 @@
+import fsPromises from 'node:fs/promises';
+
+import { getDirectories, saveRouteMap } from './utils';
+
+export const generateRouteMap = async (dir?: string) => {    
+    if (await checkAppDirectory(dir ?? './src/app')) {
+        return processRouteMap(dir ?? './src/app');
+    } else if (await checkAppDirectory(dir ?? './app')) {
+        return processRouteMap(dir ?? './app');
+    }
+
+    console.error('Error: Cannot find App directory in "src" or root directory');
+}
+
+const processRouteMap = async (directory: string) => {
+    const directoryTree = await getDirectories(directory)
+    console.log(JSON.stringify(directoryTree, null, 2));
+
+    saveRouteMap(directoryTree);
+}
+
+async function checkAppDirectory(appPath: string): Promise<boolean> {
+    try {
+        console.log('appPath', appPath);
+        const stats = await fsPromises.lstat(appPath);
+        if (stats.isDirectory()) {
+            console.log('Directory exists.');
+            return true;
+        } else {
+            console.log('Path exists but is not a directory.');
+            return false;
+        }
+    } catch (err) {
+        console.log('Directory does not exist.');
+        return false;
+    }
+}

--- a/src/routeMapGenerator.ts
+++ b/src/routeMapGenerator.ts
@@ -2,14 +2,18 @@ import fsPromises from 'node:fs/promises';
 
 import { getDirectories, saveRouteMap } from './utils';
 
-export const generateRouteMap = async (dir?: string) => {    
+export const generateRouteMap = async (dir?: string) => {
     if (await checkAppDirectory(dir ?? './src/app')) {
+        console.log('Found: The App directory was found in the src directory✅.');
         return processRouteMap(dir ?? './src/app');
-    } else if (await checkAppDirectory(dir ?? './app')) {
+    }
+
+    if (await checkAppDirectory(dir ?? './app')) {
+        console.log('Found: The App directory was found in the root directory✅.');
         return processRouteMap(dir ?? './app');
     }
 
-    console.error('Error: Cannot find App directory in "src" or root directory');
+    console.error('Error: Cannot find App directory in src or root directory❌');
 }
 
 const processRouteMap = async (directory: string) => {
@@ -21,17 +25,13 @@ const processRouteMap = async (directory: string) => {
 
 async function checkAppDirectory(appPath: string): Promise<boolean> {
     try {
-        console.log('appPath', appPath);
         const stats = await fsPromises.lstat(appPath);
         if (stats.isDirectory()) {
-            console.log('Directory exists.');
             return true;
         } else {
-            console.log('Path exists but is not a directory.');
             return false;
         }
     } catch (err) {
-        console.log('Directory does not exist.');
         return false;
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,3 +8,7 @@ export type RouteNode = {
 export type RouteMap = {
     [route: string]: RouteNode;
 };
+
+export type ConfigProp = {
+    skipNoPageFile: boolean
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,8 +37,17 @@ export async function getDirectories(dir: string, baseDir?: string): Promise<Dir
                 ...(await getDirectories(fullPath, resolvedBaseDir))
             }
         } else if (isRouteGroupDirectory(entry.name)) {
+
             const children = await getDirectories(fullPath, resolvedBaseDir);
             Object.assign(result, children);
+            
+        } else if (isDynamicDirectory(entry.name)) {
+
+            result[entry.name?.slice(1, -1)] = {
+                path: relativePath,
+                ...(await getDirectories(fullPath, resolvedBaseDir))
+            };
+            
         } else {
             result[entry.name] = {
                 path: relativePath,
@@ -60,6 +69,10 @@ function isRouteGroupDirectory(directoryName: string): boolean {
 
 function isPrivateDirectory(directoryName: string): boolean {
     return directoryName?.slice(0, 1) === "_";
+}
+
+function isDynamicDirectory(directoryName: string): boolean {
+    return directoryName?.slice(0, 1) === "[" && directoryName?.slice(0, 4) !== "[..." && directoryName?.slice(0, 5) !== "[[...";
 }
 
 async function hasPageFileInDirectory(dir: string): Promise<boolean> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,24 +1,22 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-export type DirectoryProp = Record<string, any>
+import { ConfigProp } from './types';
 
-export type ConfigProp = {
-    skipNoPageFile: boolean
-}
+export type DirectoryProp = Record<string, any>
 
 const config: ConfigProp = {
     skipNoPageFile: false
 }
 
-const initialRoute: DirectoryProp = {
+const rootRoute: DirectoryProp = {
     "/": {
         path: "/"
     }
 }
 
 export async function getDirectories(dir: string, baseDir?: string): Promise<DirectoryProp> {
-    const result: DirectoryProp = !baseDir ? initialRoute : {};
+    const result: DirectoryProp = !baseDir ? rootRoute : {};
 
     const resolvedBaseDir = baseDir ? path.resolve(baseDir) : path.resolve(dir);
 
@@ -29,7 +27,7 @@ export async function getDirectories(dir: string, baseDir?: string): Promise<Dir
 
         if (!entry.isDirectory()) continue;
         if (isPrivateDirectory(entry.name)) continue;
-        if (config?.skipNoPageFile && !(await hasPageJsInDirectory(fullPath))) continue;
+        if (config?.skipNoPageFile && !(await hasPageFileInDirectory(fullPath))) continue;
 
         const relativePath = resolveRelativePath(resolvedBaseDir, fullPath);
 
@@ -64,7 +62,7 @@ function isPrivateDirectory(directoryName: string): boolean {
     return directoryName?.slice(0, 1) === "_";
 }
 
-async function hasPageJsInDirectory(dir: string): Promise<boolean> {
+async function hasPageFileInDirectory(dir: string): Promise<boolean> {
     const pageFiles = ['page.js', 'page.ts', 'page.tsx', 'page.jsx'];
 
     for (const file of pageFiles) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,86 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export type DirectoryProp = Record<string, any>
+
+export type ConfigProp = {
+    skipNoPage: boolean
+}
+
+const config: ConfigProp = {
+    skipNoPage: true
+}
+
+const initialRoute: DirectoryProp = {
+    "/": {
+        path: "/"
+    }
+}
+
+export async function getDirectories(dir: string, baseDir?: string): Promise<DirectoryProp> {
+    const result: DirectoryProp = !baseDir ? initialRoute : {};
+
+    const resolvedBaseDir = baseDir ? path.resolve(baseDir) : path.resolve(dir);
+
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        if (isPrivateDirectory(entry.name)) continue;
+
+        const fullPath = path.join(dir, entry.name);
+
+        if (config?.skipNoPage && !(await hasPageJsInDirectory(fullPath))) continue;
+
+        const relativePath = '/' + path.relative(resolvedBaseDir, fullPath).replace(/\\/g, '/');
+
+        result[entry.name] = {
+            path: relativePath,
+            ...(await getDirectories(fullPath, resolvedBaseDir))
+        };
+    }
+
+    return result;
+};
+
+function isPrivateDirectory(directoryName: string): boolean {
+    return directoryName?.slice(0, 1) === "_";
+}
+
+async function hasPageJsInDirectory(dir: string): Promise<boolean> {
+    const pageFiles = ['page.js', 'page.ts', 'page.tsx', 'page.jsx'];
+
+    for (const file of pageFiles) {
+        const filePath = path.join(dir, file);
+        try { 
+            await fs.access(filePath);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    return false;
+}
+
+
+export async function saveRouteMap(directoryTree: DirectoryProp, savePath: string = './src/routeMap.ts') {
+    const fileContent = generateTSContent(directoryTree);
+
+    const outputPath = path.resolve(process.cwd(), savePath);
+
+    try {
+        await fs.writeFile(outputPath, fileContent, 'utf8');
+        console.log('\nrouteMap.ts file has been written successfully.');
+    } catch (error) {
+        console.error('Error writing routeMap.ts:', error);
+    }
+}
+
+function generateTSContent(directoryTree: DirectoryProp): string {
+    return `
+import { type RouteMap } from "app-router-map";
+
+export const routeMap: RouteMap = ${JSON.stringify(directoryTree, null, 2)};\n
+`;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,10 +34,17 @@ export async function getDirectories(dir: string, baseDir?: string): Promise<Dir
 
         const relativePath = '/' + path.relative(resolvedBaseDir, fullPath).replace(/\\/g, '/');
 
-        result[entry.name] = {
-            path: relativePath,
-            ...(await getDirectories(fullPath, resolvedBaseDir))
-        };
+        if (!baseDir) {
+            result['/'][entry.name] = {
+                path: relativePath,
+                ...(await getDirectories(fullPath, resolvedBaseDir))
+            }
+        } else {
+            result[entry.name] = {
+                path: relativePath,
+                ...(await getDirectories(fullPath, resolvedBaseDir))
+            };
+        }
     }
 
     return result;


### PR DESCRIPTION
* Implemented function to determine where is the `app` directory is located.
* Ignored [Router group](https://nextjs.org/docs/app/getting-started/project-structure#route-groups) directories [directories wrapped by "`()`"] and merge children to current directory.
* Added  **`skipNoPageFile`** config option to skip directories without page file.
> **Reference from official docs:** "In the app directory, nested folders define route structure. Each folder represents a route segment that is mapped to a corresponding segment in a URL path. However, even though route structure is defined through folders, a route is not publicly accessible until a page.js or route.js file is added to a route segment."
 [Next.js Docs - Project Structure](https://nextjs.org/docs/app/getting-started/project-structure)

* Ignored the directories with `router.js` since `route.js` are not use for client side navigation.
* Ignored [private directories](https://nextjs.org/docs/app/getting-started/project-structure#private-folders) (directory name is starting with `_`) using adding a condition to ignore private directories.